### PR TITLE
Add the ability to pass an object as the one and only argument

### DIFF
--- a/bem.function.php
+++ b/bem.function.php
@@ -10,14 +10,14 @@ $function = new Twig_SimpleFunction('bem', function ($context, $base_class, $mod
   $classes = [];
 
   // Add the ability to pass an object as the one and only argument.
-  if (is_object($base_class)) {
-    $object = $base_class;
+  if (is_object($base_class) || is_array($base_class)) {
+    $object = (object) $base_class;
     unset($base_class);
     $map = [
       'block' => 'base_class',
       'element' => 'blockname',
       'modifiers' => 'modifiers',
-      'classes' => 'extra',
+      'extra' => 'extra',
     ];
 
     foreach ($map as $object_key => $arg_key) {
@@ -25,6 +25,14 @@ $function = new Twig_SimpleFunction('bem', function ($context, $base_class, $mod
         $$arg_key = $object->$object_key;
       }
     }
+  }
+
+  // Ensure array arguments.
+  if (!is_array($modifiers)) {
+    $modifiers = [$modifiers];
+  }
+  if (!is_array($extra)) {
+    $extra = [$extra];
   }
 
   // If using a blockname to override default class.

--- a/bem.function.php
+++ b/bem.function.php
@@ -9,6 +9,24 @@ use Drupal\Core\Template\Attribute;
 $function = new Twig_SimpleFunction('bem', function ($context, $base_class, $modifiers = array(), $blockname = '', $extra = array()) {
   $classes = [];
 
+  // Add the ability to pass an object as the one and only argument.
+  if (is_object($base_class)) {
+    $object = $base_class;
+    unset($base_class);
+    $map = [
+      'block' => 'base_class',
+      'element' => 'blockname',
+      'modifiers' => 'modifiers',
+      'classes' => 'extra',
+    ];
+
+    foreach ($map as $object_key => $arg_key) {
+      if (isset($object->$object_key)) {
+        $$arg_key = $object->$object_key;
+      }
+    }
+  }
+
   // If using a blockname to override default class.
   if ($blockname) {
     // Set blockname class.


### PR DESCRIPTION
Add the option to call the bem() function using an object as the argument, with keys "block", "element", "modifiers" and "extra". 

e.g. {{ bem({block: "link", extra: "js-active"}) }}