### PR TITLE
Function update per 2.x Twig documentation

### DIFF
--- a/bem.function.php
+++ b/bem.function.php
@@ -6,7 +6,7 @@
 
 use Drupal\Core\Template\Attribute;
 
-$function = new Twig_SimpleFunction('bem', function ($context, $base_class, $modifiers = array(), $blockname = '', $extra = array()) {
+$function = new \Twig\TwigFunction('bem', function ($context, $base_class, $modifiers = array(), $blockname = '', $extra = array()) {
   $classes = [];
 
   // Add the ability to pass an object as the one and only argument.


### PR DESCRIPTION
Per [the deprecation notice](https://twig.symfony.com/doc/1.x/deprecated.html#functions), this PR updates the function from `Twig_SimpleFunction` to `\Twig\TwigFunction`. Everything worked OK for me in Pattern Lab and Drupal.